### PR TITLE
Update sortable.js

### DIFF
--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -225,7 +225,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 		this.helper.css( "position", "absolute" );
 		
 		//both _getRelativeOffset() and _getParentOffset() depend on cssPosition, so it should be set
-		//before calling these functions to void strange positioning on the first sorting action
+		//before calling these functions to avoid strange positioning on the first sorting action
 		this.cssPosition = this.helper.css( "position" );
 
 		$.extend( this.offset, {

--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -219,6 +219,15 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 			left: this.offset.left - this.margins.left
 		};
 
+		// After we get the helper offset, but before we get the parent offset we can
+		// change the helper's position to absolute
+		// TODO: Still need to figure out a way to make relative sorting possible
+		this.helper.css( "position", "absolute" );
+		
+		//both _getRelativeOffset() and _getParentOffset() depend on cssPosition, so it should be set
+		//before calling these functions to void strange positioning on the first sorting action
+		this.cssPosition = this.helper.css( "position" );
+
 		$.extend( this.offset, {
 			click: { //Where the click happened, relative to the element
 				left: event.pageX - this.offset.left,
@@ -227,16 +236,8 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 
 			// This is a relative to absolute position minus the actual position calculation -
 			// only used for relative positioned helper
-			relative: this._getRelativeOffset()
-		} );
-
-		// After we get the helper offset, but before we get the parent offset we can
-		// change the helper's position to absolute
-		// TODO: Still need to figure out a way to make relative sorting possible
-		this.helper.css( "position", "absolute" );
-		this.cssPosition = this.helper.css( "position" );
-
-		$.extend( this.offset, {
+			relative: this._getRelativeOffset(),
+			
 			parent: this._getParentOffset()
 		} );
 


### PR DESCRIPTION
Lines:

this.helper.css("position", "absolute");
this.cssPosition = this.helper.css("position");

should be before:

$.extend(this.offset, {
 click: { ... },
 parent: this._getParentOffset(),
 relative: this._getRelativeOffset()
});
since functions _getParentOffset() and _getRelativeOffset() depend on the value of this.cssPosition.

In fact, without this change, in some cases, the first sorting action could produce a bad positioning of the helper.